### PR TITLE
Jinja Compile

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,1 @@
+python3 -m homepage --source_dir ../homepage-content --output_dir ../homepage-output

--- a/homepage/__main__.py
+++ b/homepage/__main__.py
@@ -3,6 +3,7 @@ import os
 import sys
 from homepage.render import JinjaRenderer, MarkdownRenderer
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--source_dir", type=str, required=True)
@@ -17,6 +18,7 @@ def main():
         sys.exit(1)
 
     JinjaRenderer(source_dir, output_dir).render()
+
 
 if __name__ == "__main__":
     main()

--- a/homepage/__main__.py
+++ b/homepage/__main__.py
@@ -1,0 +1,20 @@
+import argparse
+import os
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source_dir", type=str, required=True)
+    parser.add_argument("--output_dir", type=str, required=True)
+    params = vars(parser.parse_args())
+    
+    source_dir = params["source_dir"]
+    output_dir = params["output_dir"]
+    
+    if not os.path.isdir(source_dir) or not os.path.isdir(output_dir):
+        print("Source or output directory does not exist")
+        return
+
+    render_homepage()
+
+if __name__ == "__main__":
+    main()

--- a/homepage/__main__.py
+++ b/homepage/__main__.py
@@ -1,20 +1,22 @@
 import argparse
 import os
+import sys
+from homepage.render import JinjaRenderer, MarkdownRenderer
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--source_dir", type=str, required=True)
     parser.add_argument("--output_dir", type=str, required=True)
     params = vars(parser.parse_args())
-    
+
     source_dir = params["source_dir"]
     output_dir = params["output_dir"]
-    
+
     if not os.path.isdir(source_dir) or not os.path.isdir(output_dir):
         print("Source or output directory does not exist")
-        return
+        sys.exit(1)
 
-    render_homepage()
+    JinjaRenderer(source_dir, output_dir).render()
 
 if __name__ == "__main__":
     main()

--- a/homepage/jinja_plugin.py
+++ b/homepage/jinja_plugin.py
@@ -1,0 +1,22 @@
+import re
+
+JINJA_STATEMENT_PATTERN = re.compile(r'\{\%(.*)\%\}')
+JINJA_EXPRESSION_PATTERN = r'\{\{(.*)\}\}'
+JINJA_COMMENT_PATTERN = r'\{\#(.*)\#\}'
+
+def parse_jinja_statement(self, m, state):
+    return 'jinja_statement', m.group(0)
+   
+def render_jinja_statement(string):
+    return string + 'test'
+
+def plugin_jinja(md):
+    md.block.register_rule(
+        'jinja_statement',
+        JINJA_STATEMENT_PATTERN,
+        parse_jinja_statement
+    )
+    md.block.rules.append('jinja_statement')
+
+    if md.renderer.NAME == 'html':
+        md.renderer.register('jinja_statement', render_jinja_statement)

--- a/homepage/jinja_plugin.py
+++ b/homepage/jinja_plugin.py
@@ -4,11 +4,14 @@ JINJA_STATEMENT_PATTERN = re.compile(r'\{\%(.*)\%\}')
 JINJA_EXPRESSION_PATTERN = r'\{\{(.*)\}\}'
 JINJA_COMMENT_PATTERN = r'\{\#(.*)\#\}'
 
+
 def parse_jinja_statement(self, m, state):
     return 'jinja_statement', m.group(0)
-   
+
+
 def render_jinja_statement(string):
     return string + 'test'
+
 
 def plugin_jinja(md):
     md.block.register_rule(

--- a/homepage/render.py
+++ b/homepage/render.py
@@ -12,25 +12,30 @@ class BaseRenderer:
         self.output_dir = output_dir
 
     def _render_file(self, rel_path):
-        raise NotImplementedError("Child class must implement _render_file method")
+        raise NotImplementedError(
+            "Child class must implement _render_file method")
 
     def _traverse_directory(self, map_fn):
-        def traverse_directory_helper(source_dir, output_dir, map_fn, rel_path):
+        def traverse_directory_helper(source_dir, output_dir, map_fn,
+                                      rel_path):
             for filename in os.listdir(os.path.join(source_dir, rel_path)):
                 filepath = os.path.join(source_dir, rel_path, filename)
                 if os.path.isdir(filepath):
-                    output_dirpath = os.path.join(output_dir, rel_path, filename)
+                    output_dirpath = os.path.join(
+                        output_dir, rel_path, filename)
                     if not os.path.isdir(output_dirpath):
                         os.mkdir(output_dirpath)
-                    traverse_directory_helper(source_dir, output_dir, map_fn, os.path.join(rel_path, filename))
+                    traverse_directory_helper(
+                        source_dir, output_dir, map_fn, os.path.join(rel_path,
+                                                                     filename))
                 else:
                     map_fn(os.path.join(rel_path, filename))
         traverse_directory_helper(self.source_dir, self.output_dir, map_fn, '')
 
-
     def render(self):
-        map_fn = lambda rel_path: self._render_file(rel_path)
+        def map_fn(rel_path): return self._render_file(rel_path)
         self._traverse_directory(map_fn)
+
 
 class JinjaRenderer(BaseRenderer):
     def __init__(self, source_dir, output_dir):
@@ -45,7 +50,8 @@ class JinjaRenderer(BaseRenderer):
         source_filepath = os.path.join(self.source_dir, rel_path)
         output_filepath = os.path.join(self.output_dir, rel_path)
         if re.match(r'.*\.html', filename):
-            with open(source_filepath, 'r') as source_file, open(output_filepath, 'w') as output_file:
+            with open(source_filepath, 'r') as source_file,\
+                    open(output_filepath, 'w') as output_file:
                 if filename == 'template.html':
                     print("Is template file")
                 else:
@@ -54,6 +60,7 @@ class JinjaRenderer(BaseRenderer):
                     output_file.write(template.render())
         else:
             shutil.copyfile(source_filepath, output_filepath)
+
 
 class MarkdownRenderer(BaseRenderer):
     def __init__(self, source_dir, output_dir):
@@ -64,9 +71,10 @@ class MarkdownRenderer(BaseRenderer):
         filename = os.path.basename(rel_path)
         source_filepath = os.path.join(self.source_dir, rel_path)
         output_filepath = os.path.join(self.output_dir, rel_path)
-        
+
         if re.match(r'.*\.md', filename):
-            with open(source_filepath, 'r') as source_file, open(output_filepath, 'w') as output_file:
+            with open(source_filepath, 'r') as source_file,\
+                    open(output_filepath, 'w') as output_file:
                 output_file.write(self.md(source_file.read()))
         else:
             shutil.copyfile(source_filepath, output_filepath)

--- a/homepage/render.py
+++ b/homepage/render.py
@@ -1,0 +1,72 @@
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import mistune
+from homepage.jinja_plugin import plugin_jinja
+import re
+import os
+import shutil
+
+
+class BaseRenderer:
+    def __init__(self, source_dir, output_dir):
+        self.source_dir = source_dir
+        self.output_dir = output_dir
+
+    def _render_file(self, rel_path):
+        raise NotImplementedError("Child class must implement _render_file method")
+
+    def _traverse_directory(self, map_fn):
+        def traverse_directory_helper(source_dir, output_dir, map_fn, rel_path):
+            for filename in os.listdir(os.path.join(source_dir, rel_path)):
+                filepath = os.path.join(source_dir, rel_path, filename)
+                if os.path.isdir(filepath):
+                    output_dirpath = os.path.join(output_dir, rel_path, filename)
+                    if not os.path.isdir(output_dirpath):
+                        os.mkdir(output_dirpath)
+                    traverse_directory_helper(source_dir, output_dir, map_fn, os.path.join(rel_path, filename))
+                else:
+                    map_fn(os.path.join(rel_path, filename))
+        traverse_directory_helper(self.source_dir, self.output_dir, map_fn, '')
+
+
+    def render(self):
+        map_fn = lambda rel_path: self._render_file(rel_path)
+        self._traverse_directory(map_fn)
+
+class JinjaRenderer(BaseRenderer):
+    def __init__(self, source_dir, output_dir):
+        super().__init__(source_dir, output_dir)
+        self.env = Environment(
+            loader=FileSystemLoader(source_dir),
+            autoescape=select_autoescape(['html', 'xml'])
+        )
+
+    def _render_file(self, rel_path):
+        filename = os.path.basename(rel_path)
+        source_filepath = os.path.join(self.source_dir, rel_path)
+        output_filepath = os.path.join(self.output_dir, rel_path)
+        if re.match(r'.*\.html', filename):
+            with open(source_filepath, 'r') as source_file, open(output_filepath, 'w') as output_file:
+                if filename == 'template.html':
+                    print("Is template file")
+                else:
+                    print("Rendering {0}".format(filename))
+                    template = self.env.get_template(filename)
+                    output_file.write(template.render())
+        else:
+            shutil.copyfile(source_filepath, output_filepath)
+
+class MarkdownRenderer(BaseRenderer):
+    def __init__(self, source_dir, output_dir):
+        super().__init__(source_dir, output_dir)
+        self.md = mistune.create_markdown(plugins=[plugin_jinja])
+
+    def _render_file(self, rel_path):
+        filename = os.path.basename(rel_path)
+        source_filepath = os.path.join(self.source_dir, rel_path)
+        output_filepath = os.path.join(self.output_dir, rel_path)
+        
+        if re.match(r'.*\.md', filename):
+            with open(source_filepath, 'r') as source_file, open(output_filepath, 'w') as output_file:
+                output_file.write(self.md(source_file.read()))
+        else:
+            shutil.copyfile(source_filepath, output_filepath)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo 'Running style checks'
+pycodestyle .

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+cd ../homepage-output
+python3 -m http.server


### PR DESCRIPTION
In this PR, we
* Create the `BaseRenderer` class which represents a rendering step e.g. render jinja to html. This includes methods for traversing the directory structure. The only not implemented method is the `render_file` which is dependent on the rendering step. I'm expecting there to be a total of two rendering classes: one for Jinja2 and one for Mistune (Markdown). Each step traverses through the directory structure but handles file rendering differently.
* Create the `JinjaRenderer` class which handles the Jinja2 render. 
* Create scripts for compiling and starting. This is currently specific to my computer, so I'll see later if I can generalize. 